### PR TITLE
Fix status bar handling during app startup

### DIFF
--- a/status-bar.android.ts
+++ b/status-bar.android.ts
@@ -13,14 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
-import frame = require("ui/frame");
+import application = require("application");
+
+function getActivity() {
+    return application.android.startActivity;
+}
 
 export function show()
 {
-    frame.topmost().android.activity.getWindow().getDecorView().setSystemUiVisibility(android.view.View.SYSTEM_UI_FLAG_VISIBLE);
+    getActivity().getWindow().getDecorView().setSystemUiVisibility(android.view.View.SYSTEM_UI_FLAG_VISIBLE);
 }
 
 export function hide()
 {
-    frame.topmost().android.activity.getWindow().getDecorView().setSystemUiVisibility(android.view.View.SYSTEM_UI_FLAG_FULLSCREEN);
+    getActivity().getWindow().getDecorView().setSystemUiVisibility(android.view.View.SYSTEM_UI_FLAG_FULLSCREEN);
 }


### PR DESCRIPTION
Android activity object was not available while no navigation has yet occured, so hiding or showing status bar was not possible (error message: TypeError: Cannot read property 'getWindow' of undefined)

Refactored to use the startActivity from application, which is available at this time.

Tested with Nativescript 6 and angular 8

Fix is available on npm under apolloai-nativescript-status-bar (will remove this if fix gets merged in here)

Fixes #7 , maybe also fixes #8 

